### PR TITLE
readme.md to README.md and `author.username` fallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function(app, base) {
     app.data({runner: runner});
 
     // this needs work, we need to also merge in globally persisted values
-    var person = expandPerson(app.data('author'));
+    var person = expandPerson(app.data('author'), app.cwd);
     app.data({author: person});
 
     // Create a license statement from license in from package.json
@@ -180,7 +180,7 @@ function repoFile(repo, filename) {
  * Expand person strings into objects
  */
 
-function expandPerson(str) {
+function expandPerson(str, cwd) {
   var person = {};
   if (Array.isArray(str)) {
     str.forEach(function(val) {
@@ -193,6 +193,9 @@ function expandPerson(str) {
   }
   if (!person.username && person.url && /github\.com/.test(person.url)) {
     person.username = person.url.slice(person.url.lastIndexOf('/') + 1);
+  }
+  if (!person.username) {
+    person.username = utils.gitUserName(cwd)
   }
   if (!person.twitter && person.username) {
     person.twitter = person.username;

--- a/index.js
+++ b/index.js
@@ -93,9 +93,9 @@ module.exports = function(app, base) {
 
     // load .verb.md from user cwd
     if (fs.existsSync(path.resolve(app.cwd, '.verb.md'))) {
-      app.doc('readme.md', {contents: read(app, '.verb.md', app.cwd)});
+      app.doc('README.md', {contents: read(app, '.verb.md', app.cwd)});
     } else {
-      app.doc('readme.md', {contents: read(app, '.verb.md'), layout: 'default'});
+      app.doc('README.md', {contents: read(app, '.verb.md'), layout: 'default'});
     }
 
     // load layout templates
@@ -122,7 +122,7 @@ module.exports = function(app, base) {
       .on('error', console.log)
       .pipe(app.pipeline(app.options.pipeline))
       .pipe(app.dest(function(file) {
-        file.basename = 'readme.md';
+        file.basename = 'README.md';
         return app.cwd;
       }));
   });

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gen-defaults": "^0.1.0",
     "get-pkg": "^0.2.0",
     "get-value": "^2.0.3",
+    "git-user-name": "^1.1.2",
     "helper-apidocs": "^0.5.1",
     "helper-copyright": "^2.0.1",
     "helper-date": "^0.2.2",

--- a/utils.js
+++ b/utils.js
@@ -11,6 +11,7 @@ require = utils;
 require('extend-shallow', 'extend');
 require('get-pkg', 'getPkg');
 require('get-value', 'get');
+require('git-user-name');
 require('helper-apidocs', 'apidocs');
 require('helper-copyright', 'copyright');
 require('helper-date', 'date');


### PR DESCRIPTION
- README.md is standard and you used it for long time, why you start using readme.md?
- maybe should use `parse-git-config` and `git-config-path` directly, if we want user email